### PR TITLE
Bill/travis fix

### DIFF
--- a/BusinessLayer/JsonForwarder/JsonForwarder.cpp
+++ b/BusinessLayer/JsonForwarder/JsonForwarder.cpp
@@ -55,15 +55,15 @@ void JsonForwarder::startForwardingData()
 
 void JsonForwarder::handleTimeout()
 {
-    QString currentTime = QDateTime::currentDateTime().toUTC().toString(MYSQL_DATE_FORMAT);
+    QDateTime currentTime = QDateTime::currentDateTime();
     forwardData(currentTime);
 }
 
-void JsonForwarder::forwardData(QString& currentTime)
+void JsonForwarder::forwardData(QDateTime& currentTime)
 {
     QJsonObject baseJson = QJsonObject();
     baseJson[JsonFormat::PACKET_TITLE] = PACKET_TITLE_;
-    baseJson[JsonFormat::TIMESTAMP] = currentTime;
+    baseJson[JsonFormat::TIMESTAMP] = currentTime.toUTC().toString(MYSQL_DATE_FORMAT);
 
     baseJson[JsonFormat::KEY_MOTOR] = jsonMessageBuilder_.buildKeyMotorMessage(keyMotorData_);
     baseJson[JsonFormat::MOTOR_DETAILS] = jsonMessageBuilder_.buildMotorDetailsMessage(motorDetailsData_);

--- a/BusinessLayer/JsonForwarder/JsonForwarder.cpp
+++ b/BusinessLayer/JsonForwarder/JsonForwarder.cpp
@@ -41,7 +41,7 @@ JsonForwarder::JsonForwarder(
     , forwardPeriod_(settings.forwardPeriod())
     , PACKET_TITLE_(settings.packetTitle())
 {
-    connect(readTimer_.data(), SIGNAL(timeout()), this, SLOT(forwardData()));
+    connect(readTimer_.data(), SIGNAL(timeout()), this, SLOT(handleTimeout()));
 }
 
 JsonForwarder::~JsonForwarder()
@@ -53,11 +53,16 @@ void JsonForwarder::startForwardingData()
     readTimer_->start();
 }
 
-void JsonForwarder::forwardData()
+void JsonForwarder::handleTimeout()
+{
+    QString currentTime = QDateTime::currentDateTime().toUTC().toString(MYSQL_DATE_FORMAT);
+    forwardData(currentTime);
+}
+
+void JsonForwarder::forwardData(QString& currentTime)
 {
     QJsonObject baseJson = QJsonObject();
     baseJson[JsonFormat::PACKET_TITLE] = PACKET_TITLE_;
-    QString currentTime = QDateTime::currentDateTime().toUTC().toString(MYSQL_DATE_FORMAT);
     baseJson[JsonFormat::TIMESTAMP] = currentTime;
 
     baseJson[JsonFormat::KEY_MOTOR] = jsonMessageBuilder_.buildKeyMotorMessage(keyMotorData_);

--- a/BusinessLayer/JsonForwarder/JsonForwarder.h
+++ b/BusinessLayer/JsonForwarder/JsonForwarder.h
@@ -35,9 +35,10 @@ public:
         I_Settings& settings);
     virtual ~JsonForwarder();
     void startForwardingData();
+    void forwardData(QString& currentTime);
 
 private slots:
-    void forwardData();
+    void handleTimeout();
 
 private:
     I_JsonMessageBuilder& jsonMessageBuilder_;

--- a/BusinessLayer/JsonForwarder/JsonForwarder.h
+++ b/BusinessLayer/JsonForwarder/JsonForwarder.h
@@ -35,7 +35,7 @@ public:
         I_Settings& settings);
     virtual ~JsonForwarder();
     void startForwardingData();
-    void forwardData(QString& currentTime);
+    void forwardData(QDateTime& currentTime);
 
 private slots:
     void handleTimeout();

--- a/Tests/BusinessLayer/JsonForwarder/JsonForwarderTest.cpp
+++ b/Tests/BusinessLayer/JsonForwarder/JsonForwarderTest.cpp
@@ -119,7 +119,6 @@ TEST_F(JsonForwarderTest, correctTimeStamp)
     EXPECT_CALL(*messageForwarder_, forwardData(JsonStringIs(JsonFormat::TIMESTAMP, currentTime)))
     .Times(AtLeast(1));
     jsonForwarder_->forwardData(currentTime);
-    // QTest::qWait(FORWARD_INTERVAL_MSEC + FORWARD_INTERVAL_MSEC / 2);
 }
 
 TEST_F(JsonForwarderTest, packetTitle)

--- a/Tests/BusinessLayer/JsonForwarder/JsonForwarderTest.cpp
+++ b/Tests/BusinessLayer/JsonForwarder/JsonForwarderTest.cpp
@@ -110,7 +110,7 @@ TEST_F(JsonForwarderTest, dataForwarded)
     EXPECT_CALL(*messageForwarder_, forwardData(_))
     .Times(FORWARD_ITERATIONS);
     jsonForwarder_->startForwardingData();
-    QTest::qWait(FORWARD_INTERVAL_MSEC + FORWARD_INTERVAL_MSEC / 2) * FORWARD_ITERATIONS;
+    QTest::qWait(FORWARD_INTERVAL_MSEC * FORWARD_ITERATIONS + FORWARD_INTERVAL_MSEC * 0.75);
 }
 
 TEST_F(JsonForwarderTest, correctTimeStamp)
@@ -118,8 +118,8 @@ TEST_F(JsonForwarderTest, correctTimeStamp)
     QString currentTime = QDateTime::currentDateTime().toUTC().toString(MYSQL_DATE_FORMAT);
     EXPECT_CALL(*messageForwarder_, forwardData(JsonStringIs(JsonFormat::TIMESTAMP, currentTime)))
     .Times(AtLeast(1));
-    jsonForwarder_->startForwardingData();
-    QTest::qWait(FORWARD_INTERVAL_MSEC + FORWARD_INTERVAL_MSEC / 2);
+    jsonForwarder_->forwardData(currentTime);
+    // QTest::qWait(FORWARD_INTERVAL_MSEC + FORWARD_INTERVAL_MSEC / 2);
 }
 
 TEST_F(JsonForwarderTest, packetTitle)

--- a/Tests/BusinessLayer/JsonForwarder/JsonForwarderTest.cpp
+++ b/Tests/BusinessLayer/JsonForwarder/JsonForwarderTest.cpp
@@ -115,8 +115,8 @@ TEST_F(JsonForwarderTest, dataForwarded)
 
 TEST_F(JsonForwarderTest, correctTimeStamp)
 {
-    QString currentTime = QDateTime::currentDateTime().toUTC().toString(MYSQL_DATE_FORMAT);
-    EXPECT_CALL(*messageForwarder_, forwardData(JsonStringIs(JsonFormat::TIMESTAMP, currentTime)))
+    QDateTime currentTime = QDateTime::currentDateTime();
+    EXPECT_CALL(*messageForwarder_, forwardData(JsonStringIs(JsonFormat::TIMESTAMP, currentTime.toUTC().toString(MYSQL_DATE_FORMAT))))
     .Times(AtLeast(1));
     jsonForwarder_->forwardData(currentTime);
 }

--- a/Tests/BusinessLayer/JsonForwarder/JsonForwarderTest.cpp
+++ b/Tests/BusinessLayer/JsonForwarder/JsonForwarderTest.cpp
@@ -110,7 +110,7 @@ TEST_F(JsonForwarderTest, dataForwarded)
     EXPECT_CALL(*messageForwarder_, forwardData(_))
     .Times(FORWARD_ITERATIONS);
     jsonForwarder_->startForwardingData();
-    QTest::qWait(FORWARD_INTERVAL_MSEC * FORWARD_ITERATIONS + FORWARD_INTERVAL_MSEC / 2);
+    QTest::qWait(FORWARD_INTERVAL_MSEC + FORWARD_INTERVAL_MSEC / 2) * FORWARD_ITERATIONS;
 }
 
 TEST_F(JsonForwarderTest, correctTimeStamp)


### PR DESCRIPTION
Fixes some failing tests, these now pass 10/10 times:

- Changed the waiting interval for the `dataForwarded` Tests

- Previously, `correctTimeStamp` occasionally failed by a millisecond about 30% of the time. I changed how `forwardData` is called, instead of being called right at timeout, a `timeoutHander()` is called that gets the current time and then calls `forwardData`. This allows us to test `correctTimeStamp` by calling forwardData with the current time.

