### PR TITLE
Fix MessageDecodingHelpers + More

### DIFF
--- a/CommunicationLayer/DataPopulators/KeyMotorPopulator.cpp
+++ b/CommunicationLayer/DataPopulators/KeyMotorPopulator.cpp
@@ -4,7 +4,7 @@ KeyMotorPopulator::KeyMotorPopulator(I_PacketDecoder& packetDecoder, I_KeyMotorD
     : packetDecoder_(packetDecoder)
     , keyMotorData_(keyMotorData)
 {
-    connect(&packetDecoder_, SIGNAL(packetDecoded(const KeyMotorPopulator)), this, SLOT(populateData(const KeyMotorPopulator)));
+    connect(&packetDecoder_, SIGNAL(packetDecoded(const KeyMotorMessage)), this, SLOT(populateData(const KeyMotorMessage)));
 }
 
 void KeyMotorPopulator::populateData(const KeyMotorMessage message)

--- a/CommunicationLayer/MessagingFramework/MessageDecodingHelpers.cpp
+++ b/CommunicationLayer/MessagingFramework/MessageDecodingHelpers.cpp
@@ -38,12 +38,29 @@ namespace
 
 float MessageDecodingHelpers::getFloat(const QByteArray& data, int startIndex)
 {
-    return data.mid(startIndex, numberOfBytesInData(Type::FLOAT)).toFloat();
+    float value;
+
+    QDataStream dataStream(data.mid(startIndex, numberOfBytesInData(Type::FLOAT)));
+
+    dataStream.setByteOrder(QDataStream::LittleEndian);
+    dataStream.setFloatingPointPrecision(QDataStream::SinglePrecision);
+
+    dataStream >> value;
+
+    return value;
 }
 
 unsigned short MessageDecodingHelpers::getUnsignedShort(const QByteArray& data, int startIndex)
 {
-    return data.mid(startIndex, numberOfBytesInData(Type::UNSIGNED_SHORT)).toUShort();
+    unsigned short value;
+
+    QDataStream dataStream(data.mid(startIndex, numberOfBytesInData(Type::UNSIGNED_SHORT)));
+
+    dataStream.setByteOrder(QDataStream::LittleEndian);
+
+    dataStream >> value;
+
+    return value;
 }
 
 unsigned char MessageDecodingHelpers::getUnsignedChar(const QByteArray& data, int startIndex)
@@ -53,7 +70,14 @@ unsigned char MessageDecodingHelpers::getUnsignedChar(const QByteArray& data, in
 
 unsigned int MessageDecodingHelpers::getUnsignedInt(const QByteArray& data, int startIndex)
 {
-    return data.mid(startIndex, numberOfBytesInData(Type::UNSIGNED_INT)).toUInt();
+    unsigned int value;
+
+    QDataStream dataStream(data.mid(startIndex, numberOfBytesInData(Type::UNSIGNED_INT)));
+
+    dataStream.setByteOrder(QDataStream::LittleEndian);
+
+    dataStream >> value;
+    return value;
 }
 
 

--- a/CommunicationLayer/MessagingFramework/MessageDecodingHelpers.cpp
+++ b/CommunicationLayer/MessagingFramework/MessageDecodingHelpers.cpp
@@ -36,31 +36,26 @@ namespace
     }
 }
 
-float MessageDecodingHelpers::getFloat(const QByteArray& data, int startIndex)
+template <class T>
+T readDataStream(QDataStream& dataStream)
 {
-    float value;
-
-    QDataStream dataStream(data.mid(startIndex, numberOfBytesInData(Type::FLOAT)));
-
     dataStream.setByteOrder(QDataStream::LittleEndian);
     dataStream.setFloatingPointPrecision(QDataStream::SinglePrecision);
-
+    T value;
     dataStream >> value;
-
     return value;
+}
+
+float MessageDecodingHelpers::getFloat(const QByteArray& data, int startIndex)
+{
+    QDataStream dataStream(data.mid(startIndex, numberOfBytesInData(Type::FLOAT)));
+    return readDataStream<float>(dataStream);
 }
 
 unsigned short MessageDecodingHelpers::getUnsignedShort(const QByteArray& data, int startIndex)
 {
-    unsigned short value;
-
     QDataStream dataStream(data.mid(startIndex, numberOfBytesInData(Type::UNSIGNED_SHORT)));
-
-    dataStream.setByteOrder(QDataStream::LittleEndian);
-
-    dataStream >> value;
-
-    return value;
+    return readDataStream<unsigned short>(dataStream);
 }
 
 unsigned char MessageDecodingHelpers::getUnsignedChar(const QByteArray& data, int startIndex)
@@ -70,14 +65,6 @@ unsigned char MessageDecodingHelpers::getUnsignedChar(const QByteArray& data, in
 
 unsigned int MessageDecodingHelpers::getUnsignedInt(const QByteArray& data, int startIndex)
 {
-    unsigned int value;
-
     QDataStream dataStream(data.mid(startIndex, numberOfBytesInData(Type::UNSIGNED_INT)));
-
-    dataStream.setByteOrder(QDataStream::LittleEndian);
-
-    dataStream >> value;
-    return value;
+    return readDataStream<unsigned int>(dataStream);
 }
-
-

--- a/CommunicationLayer/MessagingFramework/MessageDefines.cpp
+++ b/CommunicationLayer/MessagingFramework/MessageDefines.cpp
@@ -2,6 +2,7 @@
 
 namespace
 {
+    // Message lengths do not include metadata
     const int BATTERY_DATA_LENGTH = 51;
     const int BATTERY_FAULTS_DATA_LENGTH = 6;
     const int DRIVER_CONTROLS_DATA_LENGTH = 9;

--- a/CommunicationLayer/MessagingFramework/MessageDefines.cpp
+++ b/CommunicationLayer/MessagingFramework/MessageDefines.cpp
@@ -2,14 +2,14 @@
 
 namespace
 {
-    const int BATTERY_DATA_LENGTH = 55;
-    const int BATTERY_FAULTS_DATA_LENGTH = 10;
-    const int DRIVER_CONTROLS_DATA_LENGTH = 13;
-    const int KEY_MOTOR_DATA_LENGTH = 47;
-    const int LIGHTS_DATA_LENGTH = 7;
-    const int MOTOR_DETAILS_DATA_LENGTH = 73;
-    const int MOTOR_FAULTS_DATA_LENGTH = 13;
-    const int MPPT_DATA_LENGTH = 14;
+    const int BATTERY_DATA_LENGTH = 51;
+    const int BATTERY_FAULTS_DATA_LENGTH = 6;
+    const int DRIVER_CONTROLS_DATA_LENGTH = 9;
+    const int KEY_MOTOR_DATA_LENGTH = 43;
+    const int LIGHTS_DATA_LENGTH = 3;
+    const int MOTOR_DETAILS_DATA_LENGTH = 69;
+    const int MOTOR_FAULTS_DATA_LENGTH = 9;
+    const int MPPT_DATA_LENGTH = 10;
 }
 
 int MessageDefines::getLengthForMessage(MessageDefines::Type type)

--- a/CommunicationLayer/MessagingFramework/MessageDefines.cpp
+++ b/CommunicationLayer/MessagingFramework/MessageDefines.cpp
@@ -8,7 +8,7 @@ namespace
     const int DRIVER_CONTROLS_DATA_LENGTH = 9;
     const int KEY_MOTOR_DATA_LENGTH = 43;
     const int LIGHTS_DATA_LENGTH = 3;
-    const int MOTOR_DETAILS_DATA_LENGTH = 69;
+    const int MOTOR_DETAILS_DATA_LENGTH = 65;
     const int MOTOR_FAULTS_DATA_LENGTH = 9;
     const int MPPT_DATA_LENGTH = 10;
 }


### PR DESCRIPTION
Fixes #32 
# Changelog

- Fixed the data lengths of the decoded message (Previously, the message length constants included the metadata, however they were being used _after_ the packet was already decoded.

- Fixed a typo in KeyMotorPopulator's expecting to receive itself in it's `connect`

- Fixed the `MessageDecodingHelpers` as outlined in #32.

Check out this amazing gif to see how hermes works now:
![hermesgood](https://user-images.githubusercontent.com/15304203/35552018-3633ac60-054f-11e8-8b81-894e442c403b.gif)
