### PR TITLE
Fix copyfiles

### DIFF
--- a/src/Tests/Tests.pro
+++ b/src/Tests/Tests.pro
@@ -53,7 +53,7 @@ count(TRAVIS_DEFINED, 0) {
     QMAKE_CXXFLAGS += -Werror
 }
 
-DESTDIR = ../../build/tests
+DESTDIR = ../../build/tests/
 
 copyfiles.commands = cp testconfig.ini $${DESTDIR}
 


### PR DESCRIPTION
Here's a fix for the copyfiles error that occasionally occurs. The files were being copied to the wrong place, the DESTDIR was actually a file!