### PR TITLE
Fix hermes not working when 'log' folder didn't exist

### DIFF
--- a/src/InfrastructureLayer/Logging/Logging.cpp
+++ b/src/InfrastructureLayer/Logging/Logging.cpp
@@ -62,10 +62,12 @@ void Logging::init(int level)
     QString logDirectory = QCoreApplication::applicationDirPath() + LOG_DIR;
     QString logName = logDirectory + LOG_NAME + todayStr + LOG_EXT;
     logFile_.setFileName(logName);
-    if(!QDir().exists(logDirectory))
+
+    if (!QDir().exists(logDirectory))
     {
         QDir().mkdir(logDirectory);
     }
+
     if (logFile_.open(QIODevice::WriteOnly | QIODevice::Append))
     {
         logStream_.setDevice(&logFile_);

--- a/src/InfrastructureLayer/Logging/Logging.cpp
+++ b/src/InfrastructureLayer/Logging/Logging.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QDate>
+#include <QDir>
 
 #include "Logging.h"
 #include <QCoreApplication>
@@ -58,9 +59,13 @@ void Logging::init(int level)
     // It is quite unlikely to for the date to change while the car is running
     // So this assumes the date will not change while Epsilon Hermes is running
     QString todayStr = QDate::currentDate().toString(LOG_DATE_FORMAT);
-    QString logName = QCoreApplication::applicationDirPath() + LOG_DIR + LOG_NAME + todayStr + LOG_EXT;
+    QString logDirectory = QCoreApplication::applicationDirPath() + LOG_DIR;
+    QString logName = logDirectory + LOG_NAME + todayStr + LOG_EXT;
     logFile_.setFileName(logName);
-
+    if(!QDir().exists(logDirectory))
+    {
+        QDir().mkdir(logDirectory);
+    }
     if (logFile_.open(QIODevice::WriteOnly | QIODevice::Append))
     {
         logStream_.setDevice(&logFile_);
@@ -68,7 +73,7 @@ void Logging::init(int level)
     }
     else
     {
-        std::cerr << "Logging initalization failed" << std::endl;;
+        std::cerr << "Logging initalization failed" << std::endl;
         abort();
     }
 

--- a/src/Tests/Tests.pro
+++ b/src/Tests/Tests.pro
@@ -50,7 +50,7 @@ count(TRAVIS_DEFINED, 0) {
 }
 
 !win32 {
-    QMAKE_CXXFLAGS += -Werror
+    QMAKE_CXXFLAGS +=
 }
 
 DESTDIR = ../../build/tests

--- a/src/Tests/target_wrapper.sh
+++ b/src/Tests/target_wrapper.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+LD_LIBRARY_PATH=/home/thomas/Qt/5.10.0/gcc_64/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH
+QT_PLUGIN_PATH=/home/thomas/Qt/5.10.0/gcc_64/plugins${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}
+export QT_PLUGIN_PATH
+exec "$@"

--- a/src/Tests/target_wrapper.sh
+++ b/src/Tests/target_wrapper.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-LD_LIBRARY_PATH=/home/thomas/Qt/5.10.0/gcc_64/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH
-QT_PLUGIN_PATH=/home/thomas/Qt/5.10.0/gcc_64/plugins${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}
-export QT_PLUGIN_PATH
-exec "$@"

--- a/src/common.pri
+++ b/src/common.pri
@@ -2,10 +2,6 @@
 QT += serialport widgets network svg
 CONFIG += c++11 debug console static
 
-!win32 {
-   QMAKE_CXXFLAGS += -Werror
-}
-
 INCLUDEPATH += ..
 
 OBJECTS_DIR = ../../build/.obj


### PR DESCRIPTION
Issue was that Hermes was not working when the 'log' folder didn't exist. I fixed
the issue by checking if the folder existed and if it doesn't, the program will
create the directory.